### PR TITLE
Specified np as a development dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/halfmage/pixelarticons/issues"
   },
   "homepage": "https://github.com/halfmage/pixelarticons#readme",
-  "dependencies": {
+  "devDependencies": {
     "np": "^6.5.0"
   }
 }


### PR DESCRIPTION
At the moment the `np` package causes security warnings for packages using pixelarticons. The `np` package is very likely used only during development so it should be in `devDependencies`.