### PR TITLE
Generate font files with svgtofont

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ typings/
 
 # next.js build output
 .next
+
+# dist files
+fonts/

--- a/.svgtofontrc
+++ b/.svgtofontrc
@@ -1,0 +1,6 @@
+{
+    "fontName": "pixelart-icons-font",
+    "css": {
+        "fontSize": "24px"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Finest handmade pixelart icons.",
   "main": "index.js",
   "scripts": {
+    "font": "svgtofont --sources ./svg --output ./fonts",
     "test": "echo \"Error: no test specified\""
   },
   "repository": {
@@ -25,6 +26,7 @@
   },
   "homepage": "https://github.com/halfmage/pixelarticons#readme",
   "devDependencies": {
-    "np": "^7.6.0"
+    "np": "^7.6.0",
+    "svgtofont": "^3.23.1"
   }
 }


### PR DESCRIPTION
The font name is defaulted to `pixelart-icons-font`, and the font size is defaulted to `24px`. Run the command `npm run font` before `npm publish` will make sense.

Feel free to require a modification if you don't like them. ❤️ 

Ref: #19 