### PR TITLE
New icons: system-power and 4 mic variants

### DIFF
--- a/svg/mic.svg
+++ b/svg/mic.svg
@@ -1,0 +1,4 @@
+<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path
+    d="M8 20h8v2H8zm-1-3h10v2H7zm10-4h2v4h-2zM5 13h2v4H5z M11 18h2v3h-2zm-2-4h6v2H9z M14 3h2v12h-2z M9 2h6v2H9z M8 3h2v12H8z" fill="currentColor"/>
+</svg>

--- a/svg/mic_black.svg
+++ b/svg/mic_black.svg
@@ -1,0 +1,5 @@
+<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path
+    d="M9 15h6v1H9zM9 2h6v1H9zM8 14h8v1H8zm3-11h2v11h-2z M8 3h8v1H8zm0 8h3v2H8zm0-3h3v2H8zm0-3h3v2H8zm5 6h3v2h-3zm0-3h3v2h-3zm0-3h3v2h-3zM8 20h8v2H8zm-1-3h10v2H7zm10-4h2v4h-2zM5 13h2v4H5z M11 18h2v3h-2z"
+    fill="currentColor" />
+</svg>

--- a/svg/mic_blacker.svg
+++ b/svg/mic_blacker.svg
@@ -1,0 +1,5 @@
+<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path
+    d="M8 20h8v2H8zm-1-3h10v2H7zm10-4h2v4h-2zM5 13h2v4H5zm4 2h6v1H9z M11 18h2v3h-2zM9 2h6v1H9zM8 14h8v1H8zm2-11h4v11h-4z M8 3h8v1H8zm0 8h3v2H8zm0-3h3v2H8zm0-3h3v2H8zm5 6h3v2h-3zm0-3h3v2h-3zm0-3h3v2h-3z"
+    fill="currentColor" />
+</svg>

--- a/svg/mic_strict.svg
+++ b/svg/mic_strict.svg
@@ -1,0 +1,5 @@
+<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path
+    d="M8 20h8v2H8zm-2-3h12v2H6zm12-4h2v4h-2zM4 13h2v4H4z M11 18h2v3h-2zM9 2h6v2H9zm6 2h2v10h-2zM7 14h10v2H7zM7 4h2v10H7z"
+    fill="currentColor" />
+</svg>

--- a/svg/system-power.svg
+++ b/svg/system-power.svg
@@ -1,0 +1,5 @@
+<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path
+    d="M7 20h10v2H7zm10-2h2v2h-2zm2-8h2v8h-2zm-2-2h2v2h-2zm-2-2h2v2h-2zM5 18h2v2H5zm-2-8h2v8H3zm2-2h2v2H5zm2-2h2v2H7zm4-4h2v10h-2z"
+    fill="currentColor" />
+</svg>


### PR DESCRIPTION
Ive been using this great icon pack for my desktop widgets and was lacking mic and power button icons. 
So Ive drawn them myself. Perhaps you could make use of these. 

I couldn't stick with one mic design, so Ive pushed all my variants. 

They look like this with other icons from this pack: 

mic.svg
<img width="195" height="62" alt="mic" src="https://github.com/user-attachments/assets/354327c7-8aa4-45d7-9efc-d5c8dcecb8fa" />

mic_black.svg
<img width="191" height="59" alt="mic_black" src="https://github.com/user-attachments/assets/e5db4552-2cb2-4dd6-aba4-c6739e645718" />

mic_blacker.svg
<img width="194" height="59" alt="mic_blacker" src="https://github.com/user-attachments/assets/bdd51f95-0f47-4b5d-a486-6be2449f26c0" />

mic_strict.svg
<img width="189" height="62" alt="mic_strict" src="https://github.com/user-attachments/assets/3a6af68d-49d3-426a-93b0-1730a75b69bd" />

power.svg
<img width="147" height="59" alt="power" src="https://github.com/user-attachments/assets/6626ff70-69aa-4716-82d2-e2f25f5256c0" />
